### PR TITLE
Change the way titles are detected

### DIFF
--- a/cissors.go
+++ b/cissors.go
@@ -6,11 +6,20 @@ type Location struct {
 	Name string `yaml:"name" json:"name"`
 }
 
+type RuleType string
+
+const (
+	Scored    RuleType = "Scored"
+	NotScored RuleType = "Not Scored"
+	Manual    RuleType = "Manual"
+	Automated RuleType = "Automated"
+)
+
 // Rule describes a CIS benchmark rule
 type Rule struct {
 	ID       string            `yaml:"id" json:"id"`
 	Name     string            `yaml:"name" json:"name"`
-	Scored   bool              `yaml:"scored" json:"scored"`
+	RuleType RuleType          `yaml:"rule_type" json:"rule_type"`
 	Location []Location        `yaml:"location,omitempty" json:"location,omitempty"`
 	Sections map[string]string `yaml:"-,inline" json:"sections"`
 }


### PR DESCRIPTION
There were issues with the current code (rules not detected for the cis docker benchmark), for which I didn't manage to find a fix with the current regular expressions. This PR changes a bit how titles are detected, by looking for the "page_number of the previous rule + id of the next rule" pattern that appears of the table of contents. I can think of cases where it may break (eg. if there's a single control on the last page of the table of contents), but it works for all the benchmarks I tried.